### PR TITLE
Config refactor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,11 @@
     }
   ],
   "require": {
-    "the-shop/fortytwo-http": "^0.1.2",
+    "the-shop/fortytwo-http": "dev-master",
     "firebase/php-jwt": "^5.0"
   },
   "require-dev": {
+    "the-shop/fortytwo-base": "@dev",
     "phpunit/phpunit": "^6.3",
     "squizlabs/php_codesniffer": "^3.0"
   },

--- a/src/Module.php
+++ b/src/Module.php
@@ -13,30 +13,49 @@ class Module extends BaseModule
     /**
      * @inheritdoc
      */
-    public function bootstrap()
+    public function loadConfig()
     {
         // Let's read all files from module config folder and set to Configuration
         $configDirPath = realpath(dirname(__DIR__)) . '/config/';
         $this->setModuleConfiguration($configDirPath);
+    }
 
+    /**
+     * @inheritdoc
+     */
+    public function bootstrap()
+    {
         /**
          * @var \Framework\RestApi\RestApiApplicationInterface $application
          */
         $application = $this->getApplication();
+        /**
+         * @var RestApiConfigurationInterface $appConfig
+         */
         $appConfig = $application->getConfiguration();
 
-        // Add listeners to application
-        $listeners = $appConfig->getPathValue('listeners');
-        foreach ($listeners as $event => $arrayHandlers) {
-            foreach ($arrayHandlers as $handlerClass) {
-                $application->listen($event, $handlerClass);
+        // Register Auth Strategies
+        if (
+            empty($authStrategies = $appConfig->getPathValue('authStrategies')) === false
+        ) {
+            foreach ($authStrategies as $name => $fullyQualifiedClassName) {
+                $application->registerAuthStrategy($name, $fullyQualifiedClassName);
             }
         }
 
-        // Register Auth Strategies
-        $authStrategies = $appConfig->getPathValue('authStrategies');
-        foreach ($authStrategies as $name => $fullyQualifiedClassName) {
-            $application->registerAuthStrategy($name, $fullyQualifiedClassName);
+        // Register Acl rules
+        if (
+            empty($acl = $appConfig->getPathValue('acl')) === false
+        ) {
+            $application->setAclRules($acl);
+        }
+
+        // Register authenticatable models
+        if (
+            empty($auth = $appConfig->getAuthenticatables()) === false
+        ) {
+            $application->getRepositoryManager()
+                        ->addAuthenticatableModels($auth);
         }
     }
 }

--- a/src/RestApiConfiguration.php
+++ b/src/RestApiConfiguration.php
@@ -12,7 +12,6 @@ class RestApiConfiguration extends ApplicationConfiguration implements RestApiCo
 {
     /**
      * @return array
-     * @throws \RuntimeException
      */
     public function getAuthenticatables(): array
     {
@@ -20,23 +19,21 @@ class RestApiConfiguration extends ApplicationConfiguration implements RestApiCo
 
         $modelsConfig = $this->getPathValue('models');
 
-        if (empty($modelsConfig) === true) {
-            throw new \RuntimeException('No models defined');
-        }
-
-        foreach ($modelsConfig as $modelName => $params) {
-            if (isset($params['authenticatable']) === true &&
-                $params['authenticatable'] === true &&
-                isset($params['authStrategy']) === true &&
-                isset($params['credentials']) === true &&
-                is_array($params['credentials']) === true &&
-                isset($params['aclRoleField']) === true
-            ) {
-                $models[$params['collection']] = [
-                    'strategy' => $params['authStrategy'],
-                    'credentials' => $params['credentials'],
-                    'aclRole' => $params['aclRoleField'],
-                ];
+        if (empty($modelsConfig) === false) {
+            foreach ($modelsConfig as $modelName => $params) {
+                if (isset($params['authenticatable']) === true &&
+                    $params['authenticatable'] === true &&
+                    isset($params['authStrategy']) === true &&
+                    isset($params['credentials']) === true &&
+                    is_array($params['credentials']) === true &&
+                    isset($params['aclRoleField']) === true
+                ) {
+                    $models[$params['collection']] = [
+                        'strategy' => $params['authStrategy'],
+                        'credentials' => $params['credentials'],
+                        'aclRole' => $params['aclRoleField'],
+                    ];
+                }
             }
         }
 

--- a/test/Dummies/DummyModule.php
+++ b/test/Dummies/DummyModule.php
@@ -14,6 +14,19 @@ use Framework\RestApi\RestApiConfigurationInterface;
 class DummyModule extends BaseModule
 {
     /**
+     *
+     */
+    public function loadConfig()
+    {
+        // Let's read all files from module config folder and set to Configuration
+        $configFile = realpath(dirname(__FILE__)) . '/dummy_module.php';
+
+        $this->getApplication()
+             ->getConfiguration()
+             ->readFromPhp($configFile);
+    }
+
+    /**
      * @inheritdoc
      */
     public function bootstrap()
@@ -27,18 +40,6 @@ class DummyModule extends BaseModule
          */
         $config = $app->getConfiguration();
 
-        // Let's read all files from module config folder and set to Configuration
-        $configFile = realpath(dirname(__FILE__)) . '/dummy_module.php';
-
-        $config->readFromPhp($configFile);
-
-        // Add routes to dispatcher
-        $app->getDispatcher()
-            ->addRoutes($config->getPathValue('routes'));
-
-        // Add acl rules
-        $app->setAclRules($config->getPathValue('acl'));
-
         // Format models configuration
         $modelsConfiguration = $this->generateModelsConfiguration(
             $config->getPathValue('models')
@@ -46,31 +47,9 @@ class DummyModule extends BaseModule
 
         $repositoryManager = $app->getRepositoryManager();
 
-        $modelAdapters = $config->getPathValue('modelAdapters');
-        // Register model adapters
-        foreach ($modelAdapters as $model => $adapters) {
-            foreach ($adapters as $adapter) {
-                $repositoryManager->addModelAdapter($model, new $adapter());
-            }
-        }
-
-        $primaryModelAdapter = $config->getPathValue('primaryModelAdapter');
-        // Register model primary adapters
-        foreach ($primaryModelAdapter as $model => $primaryAdapter) {
-            $repositoryManager->setPrimaryAdapter($model, new $primaryAdapter());
-        }
-
-        $services = $config->getPathValue('services');
-        foreach ($services as $serviceName => $conf) {
-            $app->registerService(new $serviceName($conf));
-        }
-
-
         // Register resources, repositories and model fields
         $repositoryManager->registerResources($modelsConfiguration['resources'])
-                          ->registerRepositories($config->getPathValue('repositories'))
-                          ->registerModelFields($modelsConfiguration['modelFields'])
-                          ->addAuthenticatableModels($config->getAuthenticatables());
+                          ->registerModelFields($modelsConfiguration['modelFields']);
     }
 
     /**

--- a/test/UnitTest.php
+++ b/test/UnitTest.php
@@ -41,7 +41,7 @@ class UnitTest extends TestCase
             ]
         );
 
-        $this->setApplication(new DummyRestApiApplication($config));
+        $this->setApplication((new DummyRestApiApplication($config))->bootstrap());
 
         // Remove render events from the application
         $this->getApplication()


### PR DESCRIPTION
- accommodated to refactor
- `RestApiConfiguration` method `getAuthenticatables()` no longer throws `\RuntimeException`
- `Module` now registers acl rules and authenticatable models, but no longer listeners
  (base `Module` does that now)
- fixed tests and dummies
- composer dependency updated